### PR TITLE
Remove motion-system visual effects from all tool pages

### DIFF
--- a/calculators.html
+++ b/calculators.html
@@ -373,10 +373,8 @@
       }
     }
   </style>
-  <link rel="stylesheet" href="./motion-system.css" />
-  <script src="./motion-system.js" defer></script>
 </head>
-<body class="min-h-screen bg-slate-100 text-slate-800 antialiased" data-motion-page="calculator">
+<body class="min-h-screen bg-slate-100 text-slate-800 antialiased">
   <div class="responsive-shell px-4 py-6 md:px-6 md:py-8 lg:px-8 lg:py-10">
     <header class="mb-8 md:mb-10">
       <div class="hero-card relative overflow-hidden rounded-[32px] border border-sky-200/90 bg-[linear-gradient(135deg,#f8fcff_0%,#e0f2fe_52%,#dbeafe_100%)] text-slate-900 shadow-[0_32px_90px_-42px_rgba(59,130,246,0.24)] p-6 md:p-8 lg:p-10">

--- a/flight_gd_shift_tool.html
+++ b/flight_gd_shift_tool.html
@@ -632,10 +632,8 @@
       }
     }
   </style>
-  <link rel="stylesheet" href="./motion-system.css" />
-  <script src="./motion-system.js" defer></script>
 </head>
-<body data-motion-page="workbench">
+<body>
   <div class="page">
     <section class="card">
       <div class="hero">

--- a/index.html
+++ b/index.html
@@ -308,10 +308,8 @@
       }
     }
   </style>
-  <link rel="stylesheet" href="./motion-system.css" />
-  <script src="./motion-system.js" defer></script>
 </head>
-<body class="min-h-screen bg-slate-100 text-slate-800 antialiased" data-motion-page="home">
+<body class="min-h-screen bg-slate-100 text-slate-800 antialiased">
   <div class="responsive-shell px-4 py-6 md:px-6 md:py-8 lg:px-8 lg:py-10">
     <header class="mb-8 md:mb-10">
       <div class="hero-card relative overflow-hidden rounded-[32px] border border-sky-200/90 bg-[linear-gradient(135deg,#f8fcff_0%,#e0f2fe_52%,#dbeafe_100%)] text-slate-900 shadow-[0_32px_90px_-42px_rgba(59,130,246,0.24)] p-6 md:p-8 lg:p-10">

--- a/kuatian.html
+++ b/kuatian.html
@@ -125,10 +125,8 @@
       transform: scale(1.01);
     }
   </style>
-  <link rel="stylesheet" href="./motion-system.css" />
-  <script src="./motion-system.js" defer></script>
 </head>
-<body class="min-h-screen text-slate-800 antialiased" data-motion-page="workbench">
+<body class="min-h-screen text-slate-800 antialiased">
   <div class="responsive-shell px-4 py-6 md:px-6 md:py-8 lg:px-8 lg:py-10">
 
     <header class="mb-8 md:mb-10">

--- a/retime.html
+++ b/retime.html
@@ -110,10 +110,8 @@
       }
     }
   </style>
-  <link rel="stylesheet" href="./motion-system.css" />
-  <script src="./motion-system.js" defer></script>
 </head>
-<body class="min-h-screen text-slate-800 antialiased" data-motion-page="workbench">
+<body class="min-h-screen text-slate-800 antialiased">
   <div class="responsive-shell px-4 py-6 md:px-6 md:py-8 lg:px-8 lg:py-10">
     <header class="mb-8 md:mb-10">
       <div class="relative overflow-hidden rounded-[32px] border border-sky-200/90 bg-[linear-gradient(135deg,#f8fcff_0%,#e0f2fe_52%,#dbeafe_100%)] text-slate-900 shadow-[0_32px_90px_-42px_rgba(59,130,246,0.24)] p-6 md:p-8 lg:p-10">

--- a/telex.html
+++ b/telex.html
@@ -592,10 +592,8 @@
       100% { background-position: -20% 0; }
     }
   </style>
-  <link rel="stylesheet" href="./motion-system.css" />
-  <script src="./motion-system.js" defer></script>
 </head>
-<body class="min-h-screen text-slate-800 antialiased" data-motion-page="ops">
+<body class="min-h-screen text-slate-800 antialiased">
   <div class="wrap">
     <header style="margin-bottom: 18px;">
       <div class="page-header-inner">


### PR DESCRIPTION
### Motivation
- 頁面包含全域的動態特效系統（滑鼠光暈、卡片磁吸、波紋、進場動畫等），造成多餘的視覺效果與互動，需一律停用以簡化介面並照顧偏好減少動畫的使用者。 
- 變更目標是移除啟動動態系統的載入與標記，並保留現有排版與內容結構不變以維持功能與樣式一致性。

### Description
- 從 `index.html`, `calculators.html`, `retime.html`, `telex.html`, `kuatian.html`, `flight_gd_shift_tool.html` 中移除了 `motion-system.css` 與 `motion-system.js` 的 `<link>` / `<script>` 引用。 
- 移除了上述頁面 `<body>` 上的 `data-motion-page` 屬性以避免 motion runtime 自動啟動。 
- 未修改現有的頁面 DOM 結構或大多數視覺樣式（例如漸層、陰影、backdrop-blur 等保留），僅停用由 `motion-system` 提供的動態互動層與動畫觸發。 

### Testing
- 使用 `rg -n "motion-system|data-motion-page" *.html` 確認所有 HTML 檔案內不再含 `motion-system.css`, `motion-system.js` 或 `data-motion-page`（檢查結果為空，驗證成功）。
- 以小型自動化腳本（Python）執行替換以移除引用與屬性，並檢視檔案片段以確認變更已套用於 6 個 HTML 檔案（`index.html`, `calculators.html`, `retime.html`, `telex.html`, `kuatian.html`, `flight_gd_shift_tool.html`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9637e52483278e0ba28b8433d23b)