### PR TITLE
Add WebJC quick-access links in two flight tool pages

### DIFF
--- a/flight_gd_shift_tool.html
+++ b/flight_gd_shift_tool.html
@@ -651,7 +651,8 @@
             2. BY選STD(LOCAL)，TIME_TYPE選LOCAL<br>
             3. 按Query<br>
             4. 按Export Excel<br>
-            5. 將產出的檔案拖入此工具
+            5. 將產出的檔案拖入此工具<br>
+            6. <a href="https://tpeweb03.china-airlines.com:7002/webjc/" target="_blank" rel="noopener noreferrer">WebJC請點我</a>
           </div>
         </div>
         <div class="grid">

--- a/kuatian.html
+++ b/kuatian.html
@@ -143,6 +143,9 @@
           <a href="./index.html" class="shrink-0 rounded-2xl bg-white/70 text-sky-900 px-5 py-3 font-medium border border-sky-100 hover:bg-white/90 transition shadow-lg backdrop-blur-md">
             返回功能選單
           </a>
+          <a href="https://tpeweb03.china-airlines.com:7002/webjc/" target="_blank" rel="noopener noreferrer" class="shrink-0 rounded-2xl bg-sky-600 text-white px-5 py-3 font-medium border border-sky-500 hover:bg-sky-700 transition shadow-lg">
+            WebJC請點我
+          </a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Added a direct `WebJC請點我` hyperlink to `flight_gd_shift_tool.html` within the usage instructions.
- Added a prominent `WebJC請點我` button-style hyperlink in `kuatian.html` header actions.
- Both links point to: `https://tpeweb03.china-airlines.com:7002/webjc/` and open in a new tab with `rel="noopener noreferrer"`.

## Why
This makes it faster for users to access the WebJC database site directly from both tools.

## Files changed
- `flight_gd_shift_tool.html`
- `kuatian.html`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd54764048327b712ea08de866980)