### PR TITLE
UI: switch action/result accents to pink and add WebJC links

### DIFF
--- a/calculators.html
+++ b/calculators.html
@@ -647,7 +647,7 @@
                     </div>
                   </div>
                   <div class="flex flex-wrap gap-3">
-                    <button onclick="calculateFDPDeadline()" class="rounded-2xl bg-sky-600 text-white px-5 py-3 font-medium hover:bg-sky-700 transition">確認並生成 FDP 底線</button>
+                    <button onclick="calculateFDPDeadline()" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">確認並生成 FDP 底線</button>
                     <button onclick="resetFDP()" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">清除</button>
                   </div>
                 </div>
@@ -698,7 +698,7 @@
                   </div>
 
                   <div class="flex flex-wrap gap-3">
-                    <button onclick="generateFDPMessage()" class="rounded-2xl bg-cyan-600 text-white px-5 py-3 font-medium hover:bg-cyan-700 transition">手動更新電報</button>
+                    <button onclick="generateFDPMessage()" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">手動更新電報</button>
                     <button onclick="copyFDPMessage()" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">複製電報</button>
                   </div>
 
@@ -810,7 +810,7 @@
               </div>
 
               <div class="flex flex-wrap gap-3">
-                <button onclick="calculateSplitDuty()" class="rounded-2xl bg-sky-600 text-white px-5 py-3 font-medium hover:bg-sky-700 transition">確認並生成中斷工時計算結果</button>
+                <button onclick="calculateSplitDuty()" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">確認並生成中斷工時計算結果</button>
                 <button onclick="resetSplitDuty()" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">清除</button>
               </div>
             </div>
@@ -860,7 +860,7 @@
                   </div>
 
                   <div class="flex flex-wrap gap-3">
-                    <button onclick="generateSplitDutyMessage()" class="rounded-2xl bg-cyan-600 text-white px-5 py-3 font-medium hover:bg-cyan-700 transition">產生電報</button>
+                    <button onclick="generateSplitDutyMessage()" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">產生電報</button>
                     <button onclick="copySplitDutyMessage()" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">複製電報</button>
                   </div>
 
@@ -990,7 +990,7 @@
               </div>
 
               <div class="flex flex-wrap gap-3">
-                <button onclick="calculateExtensionDuty()" class="rounded-2xl bg-sky-600 text-white px-5 py-3 font-medium hover:bg-sky-700 transition">計算延長工時</button>
+                <button onclick="calculateExtensionDuty()" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">計算延長工時</button>
                 <button onclick="resetExtensionDuty()" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">清除</button>
               </div>
             </div>
@@ -1040,7 +1040,7 @@
                   </div>
 
                   <div class="flex flex-wrap gap-3">
-                    <button onclick="generateExtensionDutyMessage()" class="rounded-2xl bg-cyan-600 text-white px-5 py-3 font-medium hover:bg-cyan-700 transition">產生電報</button>
+                    <button onclick="generateExtensionDutyMessage()" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">產生電報</button>
                     <button onclick="copyExtensionDutyMessage()" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">複製電報</button>
                   </div>
 
@@ -1110,7 +1110,7 @@
         const tab = document.getElementById(id);
         if (!tab) return;
         const isActive = activeViewId === viewId;
-        tab.classList.toggle('bg-sky-600', isActive);
+        tab.classList.toggle('bg-pink-600', isActive);
         tab.classList.toggle('border-sky-600', isActive);
         tab.classList.toggle('text-white', isActive);
         tab.classList.toggle('shadow-lg', isActive);
@@ -1695,7 +1695,7 @@
 
           <div class="pt-1 border-t border-slate-200">
             <div class="text-sm text-slate-500 mb-2">FDP 底線</div>
-            <div class="rounded-2xl bg-sky-600 text-white px-5 py-4 shadow-lg">
+            <div class="rounded-2xl bg-pink-600 text-white px-5 py-4 shadow-lg">
               <div class="text-sm text-sky-100">最晚 Block In</div>
               <div class="text-2xl font-bold mt-1">${formatDateTimeUTC(deadline)} <span class="text-cyan-100 text-lg font-semibold">${dayOffsetLabel}</span></div>
             </div>
@@ -1882,7 +1882,7 @@
 
           <div class="pt-1 border-t border-slate-200">
             <div class="text-sm text-slate-500 mb-2">新 FDP 底線</div>
-            <div class="rounded-2xl bg-sky-600 text-white px-5 py-4 shadow-lg">
+            <div class="rounded-2xl bg-pink-600 text-white px-5 py-4 shadow-lg">
               <div class="text-sm text-sky-100">新的最晚 Block In</div>
               <div class="text-2xl font-bold mt-1">${formatDateTimeUTC(newDeadline)} <span class="text-cyan-100 text-lg font-semibold">${getDayOffsetLabel(start, newDeadline)}</span></div>
             </div>
@@ -2155,7 +2155,7 @@
 
           <div class="pt-1 border-t border-slate-200">
             <div class="text-sm text-slate-500 mb-2">新 FDP 底線</div>
-            <div class="rounded-2xl bg-sky-600 text-white px-5 py-4 shadow-lg">
+            <div class="rounded-2xl bg-pink-600 text-white px-5 py-4 shadow-lg">
               <div class="text-sm text-sky-100">新的最晚 Block In</div>
               <div class="text-2xl font-bold mt-1">${formatDateTimeUTC(newDeadline)} <span class="text-cyan-100 text-lg font-semibold">${getDayOffsetLabel(start, newDeadline)}</span></div>
             </div>

--- a/flight_gd_shift_tool.html
+++ b/flight_gd_shift_tool.html
@@ -651,7 +651,8 @@
             2. BY選STD(LOCAL)，TIME_TYPE選LOCAL<br>
             3. 按Query<br>
             4. 按Export Excel<br>
-            5. 將產出的檔案拖入此工具
+            5. 將產出的檔案拖入此工具<br>
+            6. <a href="https://tpeweb03.china-airlines.com:7002/webjc/" target="_blank" rel="noopener noreferrer">WebJC請點我</a>
           </div>
         </div>
         <div class="grid">

--- a/kuatian.html
+++ b/kuatian.html
@@ -143,6 +143,9 @@
           <a href="./index.html" class="shrink-0 rounded-2xl bg-white/70 text-sky-900 px-5 py-3 font-medium border border-sky-100 hover:bg-white/90 transition shadow-lg backdrop-blur-md">
             返回功能選單
           </a>
+          <a href="https://tpeweb03.china-airlines.com:7002/webjc/" target="_blank" rel="noopener noreferrer" class="shrink-0 rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium border border-pink-500 hover:bg-pink-700 transition shadow-lg">
+            WebJC請點我
+          </a>
         </div>
       </div>
     </header>
@@ -175,7 +178,7 @@
 
             <div id="dropzone" class="border-2 border-dashed border-sky-300 rounded-2xl p-8 text-center bg-sky-50/70 transition duration-200 cursor-pointer">
               <p class="text-lg text-slate-700 mb-4">拖曳 Excel 檔到這裡，或點按下方按鈕選擇檔案</p>
-              <label for="fileInput" class="inline-block cursor-pointer rounded-2xl bg-sky-600 text-white px-5 py-3 font-medium hover:bg-sky-700 transition">選擇 Excel 檔案</label>
+              <label for="fileInput" class="inline-block cursor-pointer rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">選擇 Excel 檔案</label>
               <input id="fileInput" type="file" accept=".xls,.xlsx" class="hidden" />
               <div id="uploadStatus" class="mt-4 text-sm text-slate-500">尚未選擇檔案。</div>
               <div id="progressWrap" class="mt-4" style="display:none;">
@@ -202,7 +205,7 @@
             </div>
 
             <div class="flex flex-wrap gap-3">
-              <button id="analyzeBtn" disabled class="rounded-2xl bg-sky-600 text-white px-5 py-3 font-medium hover:bg-sky-700 transition disabled:opacity-50 disabled:cursor-not-allowed">開始分析</button>
+              <button id="analyzeBtn" disabled class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition disabled:opacity-50 disabled:cursor-not-allowed">開始分析</button>
               <button id="copyBtn" disabled class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition disabled:opacity-50 disabled:cursor-not-allowed">複製結果</button>
               <button id="downloadBtn" disabled class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition disabled:opacity-50 disabled:cursor-not-allowed">下載 TXT</button>
               <button id="clearBtn" class="rounded-2xl bg-cyan-50 text-cyan-800 border border-cyan-200 px-5 py-3 font-medium hover:bg-cyan-100 transition">清空</button>

--- a/retime.html
+++ b/retime.html
@@ -168,7 +168,7 @@
             </div>
 
             <div class="flex flex-wrap gap-3">
-              <button onclick="calculateReTimeNotice()" class="rounded-2xl bg-sky-600 text-white px-5 py-3 font-medium hover:bg-sky-700 transition">確認並產生通知</button>
+              <button onclick="calculateReTimeNotice()" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">確認並產生通知</button>
               <button onclick="resetReTime()" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">清除</button>
             </div>
           </div>
@@ -198,7 +198,7 @@
               請先完成上方必填欄位後產生通知。
             </div>
             <div class="flex flex-wrap gap-3">
-              <button onclick="copyReTimeNotice()" class="rounded-2xl bg-cyan-600 text-white px-5 py-3 font-medium hover:bg-cyan-700 transition">一鍵複製通知內容</button>
+              <button onclick="copyReTimeNotice()" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">一鍵複製通知內容</button>
             </div>
           </div>
         </section>
@@ -339,7 +339,7 @@
           </div>
           <div class="pt-1 border-t border-slate-200">
             <div class="text-sm text-slate-500 mb-2">BOT Reporting Time</div>
-            <div class="rounded-2xl bg-sky-600 text-white px-5 py-4 shadow-lg">
+            <div class="rounded-2xl bg-pink-600 text-white px-5 py-4 shadow-lg">
               <div class="text-sm text-sky-100">BOT報到時間</div>
               <div class="text-2xl font-bold mt-1">${botStr}</div>
             </div>

--- a/telex.html
+++ b/telex.html
@@ -633,7 +633,7 @@
           <div class="panel-body">
             <textarea id="sourceInput" spellcheck="false" placeholder="請貼上 ASM 電報內容..."></textarea>
             <div class="toolbar">
-              <button id="parseBtn" class="rounded-2xl bg-sky-600 text-white px-5 py-3 font-medium hover:bg-sky-700 transition">整理電報</button>
+              <button id="parseBtn" class="rounded-2xl bg-pink-600 text-white px-5 py-3 font-medium hover:bg-pink-700 transition">整理電報</button>
               <button id="clearBtn" class="rounded-2xl bg-cyan-50 text-cyan-800 border border-cyan-200 px-5 py-3 font-medium hover:bg-cyan-100 transition">清空</button>
               <button id="copyBtn" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">複製表格 TSV</button>
               <button id="csvBtn" class="rounded-2xl bg-sky-50 text-sky-900 border border-sky-200 px-5 py-3 font-medium hover:bg-sky-100 transition">匯出 CSV</button>


### PR DESCRIPTION
### Motivation

- Refresh the UI accent for action buttons and prominent result panels from the original sky/cyan theme to a pink accent to match updated design direction. 
- Surface a quick link to the WebJC tool in pages where users are instructed to export data from WebJC for easier access.

### Description

- Replaced color classes for primary action buttons and prominent result panels from `bg-sky-600`/`bg-cyan-600` to `bg-pink-600` and hover states to `bg-pink-700` across multiple pages including `calculators.html`, `flight_gd_shift_tool.html`, `kuatian.html`, `retime.html`, and `telex.html`.
- Updated tab activation styling in `calculators.html` JavaScript to toggle `bg-pink-600` instead of `bg-sky-600` in `updateCalculatorTabs`.
- Added direct `WebJC` links in `flight_gd_shift_tool.html` instructions and as a shortcut button in the header of `kuatian.html` for quicker access to the WebJC export workflow.
- These are presentation-only changes; no algorithmic or business logic was altered.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd54764048327b712ea08de866980)